### PR TITLE
If altLabel is used as fallback, use copy instead of move (#24)

### DIFF
--- a/ddc/ddc2jskos.fix
+++ b/ddc/ddc2jskos.fix
@@ -70,7 +70,7 @@ marc_map(753$a,altLabel.$append)
 
 unless exists(prefLabel)
   if exists(altLabel)
-    move(altLabel.$first, prefLabel)
+    copy(altLabel.$first, prefLabel)
   end
 end
 


### PR DESCRIPTION
See #24 for more information.